### PR TITLE
Update scrying.json

### DIFF
--- a/images/provisioners/default.json
+++ b/images/provisioners/default.json
@@ -20,7 +20,7 @@
         "DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confnew dist-upgrade -qq",
 
         "echo 'Installing ufw fail2ban net-tools zsh jq build-essential python3-pip unzip git p7zip libpcap-dev rubygems ruby-dev grc'",
-        "sudo apt install fail2ban ufw net-tools zsh zsh-syntax-highlighting zsh-autosuggestions jq build-essential python3-pip unzip git p7zip libpcap-dev rubygems ruby-dev grc -y -qq",
+        "sudo apt install fail2ban ufw net-tools zsh zsh-syntax-highlighting zsh-autosuggestions jq build-essential python3-pip unzip git p7zip libpcap-dev rubygems ruby-dev grc xvfb -y -qq",
         "ufw allow 22",
         "ufw allow 2266",
         "ufw --force enable",

--- a/modules/scrying.json
+++ b/modules/scrying.json
@@ -1,4 +1,4 @@
 [{
-	"command":"xvfb-run scrying -f input --output-dir output",
+	"command":"sudo xvfb-run scrying -f input --output output",
 	"ext":""
 }]


### PR DESCRIPTION
updated to correct parameters and requiring sudo 
``thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: IoError("Permission denied (os error 13)")', src/web/linux.rs:226:26
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
^CGdk-Message: 18:16:14.987: scrying: Fatal IO error 11 (Resource temporarily unavailable) on X server :99.``